### PR TITLE
nsIEffectiveTLDService

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,7 +1,9 @@
 var obSvc = require('observer-service');
 var prefs = require('preferences-service');
 var data = require("self").data;
-var {Ci, Cr} = require('chrome');
+var {Cc, Ci, Cr} = require('chrome');
+var eTLDSvc = Cc["@mozilla.org/network/effective-tld-service;1"].
+                getService(Ci.nsIEffectiveTLDService);
 
 var baseUrls = prefs.get("collusion.urls",
                          "http://collusion.toolness.org/")
@@ -52,18 +54,14 @@ function queueInfo(info) {
   }
 }
 
-function getDomain(host) {
-  return host.split('.').slice(-2).join('.');
-}
-
 obSvc.add("http-on-examine-response", function(subject, topic, data) {
   var channel = subject.QueryInterface(Ci.nsIHttpChannel),
       type = null,
       cookie = null;
 
   if (channel.referrer) {
-    var referrerDomain = getDomain(channel.referrer.host);
-    var domain = getDomain(channel.URI.host);
+    var referrerDomain = eTLDSvc.getBaseDomainFromHost(channel.referrer.host);
+    var domain = eTLDSvc.getBaseDomainFromHost(channel.URI.host);
     if (domain != referrerDomain) {
       try {
         type = subject.getResponseHeader("Content-Type");


### PR DESCRIPTION
I've wanted to use the nsIEffectiveTLDService since I first saw it but haven't had an extension that needed it.  Finally my time has come!  I hope my style is inline with yours.

I've replaced the getDomain() function with direct calls to the service function getBaseDomainFromHost().

Previously a host like `node1.bbcimg.co.uk` would be found and the domain splitting would return `co.uk` instead of `bbcimg.co.uk`
