### PR TITLE
Changed com.com to cnet.com,    com.com looked like a typo in the demo! ...

### DIFF
--- a/website/sample-tracking-info.json
+++ b/website/sample-tracking-info.json
@@ -28,7 +28,7 @@
 
 "advertising.com":{"referrers":{"atwola.com":[263125,"image/gif"]}},
 
-"com.com":{"referrers":{"gamespot.com":[350513,"text/plain","image/gif"]}},
+"cnet.com":{"referrers":{"gamespot.com":[350513,"text/plain","image/gif"]}},
 
 "bluekai.com":{"referrers":{"gamespot.com":[351413,"text/html","text/javascript"]}},
 


### PR DESCRIPTION
... - The favicon is clearly cnet.com  and com.com redirects there.
