### PR TITLE
Don't record information about sites visited in Private Browsing mode (take 2)

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -11,6 +11,8 @@ var ioService = Cc["@mozilla.org/network/io-service;1"]
                   .getService(Ci.nsIIOService);
 var cookieMgr = Cc["@mozilla.org/cookiemanager;1"]
                     .getService(Ci.nsICookieManager2);
+var privateBrowsingSvc = Cc["@mozilla.org/privatebrowsing;1"]
+                    .getService(Components.interfaces.nsIPrivateBrowsingService);
 var deployment = {};
 var baseUrls = [];
 var baseHosts = {};
@@ -49,7 +51,9 @@ function attachToCollusionPage(worker) {
     log = {};
   });
   worker.port.on("save", function(data) {
-    storage.graph = data;
+    if (!privateBrowsingSvc.privateBrowsingEnabled) {
+      storage.graph = data;
+    }
   });
   worker.port.on("getSavedGraph", function() {
     var graph = "{}";
@@ -204,6 +208,10 @@ obSvc.add("http-on-examine-response", function(subject, topic, data) {
       }
     }
   }
+});
+
+obSvc.add("private-browsing", function(subject, topic, data) {
+  log = {};
 });
 
 // When a site loads in a tab, make a record that the domain is one actively


### PR DESCRIPTION
This is a better fix for issue #66.  This still allows the Collusion visualization to work in Private Browsing mode, but it (a) does not save information to disk during Private Browsing, and (b) resets the graph when entering or exiting Private Browsing mode.  This prevents Collusion from leaking data about sites visited during Private Browsing.
