### PR TITLE
Detects user navigation even if it's loading in a background tab

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -43,7 +43,7 @@ var startTime = new Date();
 var collusionPanel = null;
 
 
-function getHistoryForActiveTab() {
+function getHistoryForTab(tabIndex) {
     /* Because there doesn't seem to be a Jetpacky way of getting history,
      * I wrote this function that uses XPCOM.
      * Returns an array of strings containing domain names,
@@ -51,8 +51,9 @@ function getHistoryForActiveTab() {
      * visited in this tab.*/
 
     var frontWind = windowMediator.getMostRecentWindow("navigator:browser");
-    var gb = frontWind.gBrowser;
-    var sessionHistory = frontWind.gBrowser.sessionHistory;
+    var loadingTab = frontWind.gBrowser.tabContainer.getItemAtIndex(tabIndex);
+    // See https://developer.mozilla.org/en-US/docs/Code_snippets/Tabbed_browser
+    var sessionHistory = loadingTab.linkedBrowser.sessionHistory;
     // see https://developer.mozilla.org/en-US/docs/XPCOM_Interface_Reference/nsISHistory
     var enumr = sessionHistory.SHistoryEnumerator;
 
@@ -501,10 +502,11 @@ function initCollusion() {
      * two domains. Because they are successive in history, you got from one
      * to the other via a navigation event. So add "navigation" to the list
      * of data types for the link. */
-      var history = getHistoryForActiveTab();
+      var history = getHistoryForTab(tab.index);
       if (history.length >= 2) {
         var previousDomain = getDomain( history[ history.length - 2 ] );
         if (domain != previousDomain) {
+	    console.log("Looks like you navigated from " + previousDomain + " to " + domain);
           queueInfo({domain: domain,
                      referrer: previousDomain,
                      type: "user_navigation"});


### PR DESCRIPTION
Update to issue 6 patch: Changed the getHistory function to get history for the loading tab, not the active tab. This way we detect user navigation events even if they are happening in an unfocused tab.

If you already had Collusion open when the navigation happened, you will temporarily see a link between the two domains you navigated between, but this is just a stale graph issue (similar to issue #58): if you reload the collusion page it will go away.
