### PR TITLE
[Issue#283] Shows list items that have preferences at the top

### DIFF
--- a/data/list.js
+++ b/data/list.js
@@ -323,11 +323,11 @@ function sortTableOnColumn(table, n){
             // Check if there are any preferences set for this row
             var prefVal = rowElement.attributes.getNamedItem('data-pref').value;
 
-            if (prefCol && prefVal != '') {
-                // This row is marked with a preference. We should 
-                // append it to the top fragment
+            if (prefCol && prefVal != ''){
+                // This row is marked with a preference and should
+                // be appended to the top fragment.
                 preFrag.appendChild(rowElement);
-            } else {
+            }else{
                 frag.appendChild(rowElement);
             }
          });


### PR DESCRIPTION
I added another document fragment which gets all the elements that have their data-pref attribute set and then goes on to append itself at the top of the list when the user sorts it.
