### PR TITLE
Update README.md's link for the addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Collusion README
 
-This is an add-on for Firefox that helps to visualize sites that may be tracking you around the internet. The add-on is available from https://addons.mozilla.org/en-US/firefox/addon/collusion/.
+This is an add-on for Firefox that helps to visualize sites that may be tracking you around the internet. The add-on is available from https://addons.mozilla.org/en-US/firefox/addon/lightbeam/.
 
 
 ## Prerequisites


### PR DESCRIPTION
The name seems to have been changed, and although the link in the repo description was updated the README.md wasn't.
