### PR TITLE
Fixed singular/plural logic

### DIFF
--- a/data/lightbeam.js
+++ b/data/lightbeam.js
@@ -169,7 +169,7 @@ global.singularOrPluralNoun = function singularOrPluralNoun(num,str){
     if ( typeof num != "number" ){
         num = parseFloat(num);
     }
-    return ( num > 1) ? str+"s" : str;
+    return ( num !== 1) ? str+"s" : str;
 }
 
 /****************************************


### PR DESCRIPTION
I have changed it so that singularOrPluralNoun returns plural unless parameter "num" = 1.  Before, it would say things like "0 external site," which is not proper grammar.  It now correctly says "0 external sites."
