### PR TITLE
Remove link to Feedback Google Docs (fix #501)

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -38,7 +38,7 @@
                 </a>
             </div>
             <div class="links">
-                <img src="image/lightbeam_icon_feedback.png"> <a href="https://docs.google.com/a/mozillafoundation.org/forms/d/1QeVKe8xDwmaJMqiWDBs1eCR8kpDGaUDdanUWIn-xn1Q/viewform" target="_blank">Give Us Feedback</a><br />
+                <img src="image/lightbeam_icon_feedback.png"> <a href="mailto:lightbeam-feedback@mozilla.org">Give Us Feedback</a><br />
                 <a href="http://www.mozilla.org/lightbeam" target="_blank">mozilla.org/lightbeam</a>
             </div>
         </aside>


### PR DESCRIPTION
If we're not looking at the feedback (as mentioned in #501), it's probably important that people don't waste time filling out the form.
