### PR TITLE
call correct highlightNodes function, fixes #550

### DIFF
--- a/data/graph.js
+++ b/data/graph.js
@@ -51,7 +51,7 @@ function onUpdate() {
     force.links(filteredAggregate.edges);
     force.start();
     updateGraph();
-    global.colourHighlightNodes(highlight);
+    colourHighlightNodes(highlight);
   } else {
     console.log('the force is not with us');
   }


### PR DESCRIPTION
colourHighlightNodes is never added to the global object, so calling it that
way resulted in a "function undefined" error. I believe this was due to an
earlier PR comment where I recommended we not add it to global because it is
only ever used inside graph.js. This is probably a leftover line that wasn't
changed for that comment.
