### PR TITLE
send stored connections to ui in batches

### DIFF
--- a/lib/ui.js
+++ b/lib/ui.js
@@ -20,6 +20,9 @@ const {
   on, once, off, emit
 } = require("sdk/event/core");
 const prefs = require("sdk/simple-prefs").prefs;
+const {
+  setTimeout
+} = require("sdk/timers");
 
 const persist = require("./persist");
 const {
@@ -187,7 +190,26 @@ function attachToLightbeamPage(worker) {
 
   function onUIReady() {
     worker.port.emit("updateUIFromPrefs", prefs);
-    worker.port.emit("passStoredConnections", getAllConnections());
+
+    const BATCH_SIZE = 500; // # connections to pass at a time
+    const BATCH_INTERVAL = 50; // ms
+    let connections = getAllConnections();
+    let batchStart = 0;
+
+    setTimeout(function passStoredConnBatch() {
+      // Note: If the second paramter of Array.slice is greater than the length
+      // of the array, it returns up to the end of the array.
+      let batchEnd = batchStart + BATCH_SIZE;
+      let slice = connections.slice(batchStart, batchEnd);
+      console.log("Passing connections " + batchStart + " - " + batchEnd);
+      worker.port.emit("passStoredConnections", slice);
+      if (batchStart >= connections.length) {
+        return;
+      } else {
+        batchStart = batchEnd;
+        setTimeout(passStoredConnBatch, BATCH_INTERVAL);
+      }
+    }, 0);
   }
 
   function onWorkerDetach() {


### PR DESCRIPTION
Batches sending the "stored connections" from the addon-side simple-storage to the UI when the tab is opened.

All parameters (batch size, setTimeout delay) are chosen fairly arbitrarily, with some influence from [this article on yielding with JS timers](http://answers.oreilly.com/topic/1506-yielding-with-javascript-timers/).

This works well on my Linux machine, but I ran into some issues testing it with my "normal profile". After digging around, it seems like there might be a bug elsewhere with the way we're deleting things to stay under quota (which I will try to look into more, later). In the meantime, I'm interested in hearing how smooth, fast, and janky-or-not things are on other platforms (since my Firefox on Linux doesn't have GPU support, the graph rendering is invariably janky).

Should close #572.
