### PR TITLE
fix map dragging in infobar

### DIFF
--- a/data/infobar.js
+++ b/data/infobar.js
@@ -7,6 +7,8 @@
 
 var g = global;
 global.initMap = function initMap(mapcanvas, mapDocument) {
+  var onDragMap = false;
+  var mapDragStart = {};
 
   var oriMapViewBox = mapcanvas.getAttribute('viewBox');
 

--- a/data/ui.js
+++ b/data/ui.js
@@ -315,9 +315,7 @@ function generateNewViewBox(target, box, ratio) {
 /* Pan by dragging ======================================== */
 
 var onDragGraph = false;
-var onDragMap = false;
 var graphDragStart = {};
-var mapDragStart = {};
 
 /* vizcanvas */
 document.querySelector(".stage").addEventListener("mousedown", function (event) {


### PR DESCRIPTION
Dragging the map in the infobar was broken, because the state variables it needed are declared in `data/ui.js` but are used in `data/infobar.js`. After infobar.js was namespaced in a recent refactor, it was unable to access these state variables. Fixed by moving the state variables from `ui.js` to `infobar.js`, since they are only needed there and are kept alive via closure.

The console errors from #588 were also caused by this issue. Fixes #588.
