### PR TITLE
Some buttons break at large text sizes

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -303,7 +303,7 @@ a:hover{
     display: inline-block;
     background: #5F6771;
     border-radius: 5px;
-    width: 60px;
+    width: 5.5em;
     height: 28px;
     padding: 3px;
     cursor: pointer;
@@ -1163,7 +1163,7 @@ text {
 
 .list-footer .align-left .btn{
     float: left;
-    width: 140px;
+    width: 160px;
     margin-right: 20px;
 }
 


### PR DESCRIPTION
When the browser is set with a large minimum text size,
the following buttons break. Increasing sizes to fit.
All other buttons fit just fine.

* Contribute Data switch
* Clear Preference button