### PR TITLE
Clean up const usage in ui.js broken by SpiderMonkey changes.

### DIFF
--- a/lib/ui.js
+++ b/lib/ui.js
@@ -23,15 +23,12 @@ const {
 
 const xulapp = require("sdk/system/xul-app");
 const usingAustralis = xulapp.satisfiesVersion(">=29");
-if (usingAustralis) {
-  const {
-    ActionButton
-  } = require("sdk/ui/button/action");
-} else {
-  const {
-    Widget
-  } = require("sdk/widget");
-}
+const {
+  ActionButton
+} = usingAustralis ? require("sdk/ui/button/action") : undefined;
+const {
+  Widget
+} = !usingAustralis ? require("sdk/widget") : undefined;
 exports.usingAustralis = usingAustralis;
 
 const mainPage = data.url("index.html");


### PR DESCRIPTION
THIS HAS NOT HAD TESTS RUN. I am struggling to get lightbeam running locally for really silly reasons. This should fix the errors introduced by SpiderMonkey `const` changes, though.
