### PR TITLE
Revert "Fix call to isWindowPrivate"

### DIFF
--- a/lib/tab/utils.js
+++ b/lib/tab/utils.js
@@ -63,7 +63,7 @@ function getTabForChannel(aHttpChannel) {
   if (win) {
     var tab = getTabForContentWindow(win);
     // http://developer.mozilla.org/en/docs/XUL:tab
-    tab.isPrivate = PrivateBrowsingUtils.isContentWindowPrivate(win);
+    tab.isPrivate = PrivateBrowsingUtils.isWindowPrivate(win);
     return tab;
   } else {
     // console.error('getTabForChannel() no topWindow found');


### PR DESCRIPTION
This reverts commit 53f4696d9ea1a67103a25537d80194808bd201dc.

I merged #625 too soon. It broke support for Firefox 31 (currently ESR). Let's revert that commit (and bring back the annoying warning) until we find the right fix for this.
