### PR TITLE
Remove references to the Lightbeam mailing list

### DIFF
--- a/data/first-run.html
+++ b/data/first-run.html
@@ -37,7 +37,6 @@
       <li>
         <ul id="contact">
           <li>Learn more about Mozilla's Lightbeam for Firefox on our <a href="https://mozilla.org/lightbeam">project page</a></li>
-          <li>Question? Idea? Email the mailing list: <a href="mailto:lightbeam-feedback@mozilla.org" target="_blank">lightbeam@mozilla.org</a></li>
           <li>Found a bug? <a href="https://github.com/mozilla/lightbeam/issues/new" target="_blank">Report an issue</a> on Github</li>
           <li>Don't forget to <a href="https://addons.mozilla.org/en-US/firefox/addon/lightbeam/reviews/add" target="_blank">leave a review</a> on our Mozilla Addons page!</li>
         </ul>

--- a/data/upgrade.html
+++ b/data/upgrade.html
@@ -32,7 +32,6 @@ repository</a>.</p>
       <li>
         <ul id="contact">
           <li>Learn more about Mozilla's Lightbeam for Firefox on our <a href="https://mozilla.org/lightbeam">project page</a></li>
-          <li>Question? Idea? Email the mailing list: <a href="mailto:lightbeam-feedback@mozilla.org" target="_blank">lightbeam-feedback@mozilla.org</a></li>
           <li>Found a bug? <a href="https://github.com/mozilla/lightbeam/issues/new" target="_blank">Report an issue</a> on Github</li>
           <li>Don't forget to <a href="https://addons.mozilla.org/en-US/firefox/addon/lightbeam/reviews/add" target="_blank">leave a review</a> on our Mozilla Addons page!</li>
         </ul>


### PR DESCRIPTION
Since we're not actively responding to questions and ideas, we
should not emphasize the feedback email alias too much.
