### PR TITLE
Add "min-height:0" to flex items, to disable flexbox min-content sizing ...

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -351,6 +351,7 @@ a:hover{
     z-index: 0;
     border-top: 1px solid #555555;
     height: 100%;
+    min-height: 0;
 }
 
 .content-flex{
@@ -634,6 +635,7 @@ a:hover{
 
 .stage{
     flex: 1;
+    min-height: 0;
     /*margin: 20px 0px;*/
 }
 .showinfo .stage-stack{


### PR DESCRIPTION
This should fix issue #637.  (I haven't actually built & tested lightbeam, but I made these exact edits to the release LightBeam add-on via Firefox's DevTools and I confirmed that the list became scrollable again (and reasonably-sized) and the controls reappeared at the bottom again.