### PR TITLE
Use isContentWindowPrivate() when available (fix #616)

### DIFF
--- a/lib/tab/utils.js
+++ b/lib/tab/utils.js
@@ -63,7 +63,11 @@ function getTabForChannel(aHttpChannel) {
   if (win) {
     var tab = getTabForContentWindow(win);
     // http://developer.mozilla.org/en/docs/XUL:tab
-    tab.isPrivate = PrivateBrowsingUtils.isWindowPrivate(win);
+    if (PrivateBrowsingUtils.isContentWindowPrivate) {
+      tab.isPrivate = PrivateBrowsingUtils.isContentWindowPrivate(win);
+    } else {
+      tab.isPrivate = PrivateBrowsingUtils.isWindowPrivate(win); // ESR 31
+    }
     return tab;
   } else {
     // console.error('getTabForChannel() no topWindow found');


### PR DESCRIPTION
As suggested by @dholbert on https://github.com/mozilla/lightbeam/pull/625#issuecomment-66811302