### PR TITLE
Sorting arrow displays upside down in grid view. (Fix #453)

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -604,7 +604,6 @@ a:hover{
 .sorted:after, .reverse-sorted:after{
     padding:0px 5px;
     content: '▾';
-    display: inline-block;
     position: relative;
     -moz-transition:all 0.3s linear;
 }


### PR DESCRIPTION
The inline-block was causing the arrow to display upside down (▴ rather than ▾).  This resolves issue #453. 