### PR TITLE
Don't use singular noun for 0 items.

### DIFF
--- a/data/ui.js
+++ b/data/ui.js
@@ -440,7 +440,7 @@ global.singularOrPluralNoun = function singularOrPluralNoun(num, str) {
   if (typeof num != "number") {
     num = parseFloat(num);
   }
-  return (num > 1) ? str + "s" : str;
+  return (num === 1) ? str : str + "s";
 };
 
 function updateUIFromMetadata(event) {


### PR DESCRIPTION
For example, when you have just started using Lightbeam and haven't visited a website yet it should say '0 websites' instead of '0 website'.