### PR TITLE
Updated "Quickstart" section install link for cfx

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This will start Firefox with a temporary profile that has Lightbeam installed. J
 
 At this point, any changes you make to the web front-end simply require reloading the tab containing it. Changing the add-on, however, will require quitting Firefox and running `cfx run` again.
 
-  [install]: https://developer.mozilla.org/en-US/Add-ons/SDK/Tutorials/Installation
+  [install]: http://www.palemoon.org/dev/addon-sdk/dev-guide/tutorials/getting-started-with-cfx.html
 
 ## Software Used
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This will start Firefox with a temporary profile that has Lightbeam installed. J
 
 At this point, any changes you make to the web front-end simply require reloading the tab containing it. Changing the add-on, however, will require quitting Firefox and running `cfx run` again.
 
-  [install]: http://www.palemoon.org/dev/addon-sdk/dev-guide/tutorials/getting-started-with-cfx.html
+  [install]: https://developer.mozilla.org/en-US/Add-ons/SDK/Tutorials/Installation$revision/894679
 
 ## Software Used
 


### PR DESCRIPTION
Updated install link to point to http://www.palemoon.org/dev/addon-sdk/dev-guide/tutorials/getting-started-with-cfx.html