### PR TITLE
Fix logging websites in multiprocess Firefox

### DIFF
--- a/lib/tab/utils.js
+++ b/lib/tab/utils.js
@@ -61,33 +61,7 @@ function getTabForChannel(aHttpChannel) {
     return getTabForChannel2(aHttpChannel);
   }
 
-  var tab = null;
-  if (loadContext.topFrameElement) {
-    var browser = loadContext.topFrameElement;
-    tab = getTabForBrowser(browser);
-
-    if ( tab ) {
-      tab.isPrivate = PrivateBrowsingUtils.isBrowserPrivate(browser);
-    } else {
-      // this function should return null if no tab can be found, not undefined
-      tab = null;
-    }
-  } else if (loadContext.topWindow) {
-    // Fallback for Firefox < 38, where topFrameElement is not defined when not
-    // in multiprocess mode. Note that this method crashes in multiprocess
-    // Firefox
-    var win = loadContext.topWindow;
-    tab = getTabForContentWindow(win);
-
-    // http://developer.mozilla.org/en/docs/XUL:tab
-    if (PrivateBrowsingUtils.isContentWindowPrivate) {
-      tab.isPrivate = PrivateBrowsingUtils.isContentWindowPrivate(win);
-    } else {
-      tab.isPrivate = PrivateBrowsingUtils.isWindowPrivate(win); // ESR 31
-    }
-  }
-
-  return tab;
+  return getTabForLoadContext(loadContext);
 }
 
 // Special case in case we don't have a load context.
@@ -97,6 +71,53 @@ function getTabForChannel2(aChannel) {
 
   var tab = getTabForContentWindow(win);
   return tab;
+}
+
+// Get the tab for a LoadContext
+function getTabForLoadContext(aLoadContext) {
+    var browser = aLoadContext.topFrameElement;
+    if (browser) {
+      // Should work in e10s or in non-e10s Firefox >= 39
+      var tab = getTabForBrowser(browser);
+
+      if ( tab ) {
+        tab.isPrivate = PrivateBrowsingUtils.isBrowserPrivate(browser);
+        return tab;
+      }
+    }
+
+    // fallback
+    return getTabForLoadContext2(aLoadContext);
+}
+
+// Fallback for when we can't get the tab for a LoadContext via
+// topFrameElement. This happens in:
+//    * Firefox < 38, where topFrameElement is not defined when not
+//      in e10s.
+//    * Firefox 38, where topFrameElement is defined when not in e10s, but
+//      the getTabForBrowser call fails
+//    * other cases where the tab simply cannot be figured out. This function
+//      will return null in these cases.
+function getTabForLoadContext2(aLoadContext) {
+  try {
+    var win = aLoadContext.topWindow;
+    if (win) {
+      var tab = getTabForContentWindow(win);
+
+      // http://developer.mozilla.org/en/docs/XUL:tab
+      if (PrivateBrowsingUtils.isContentWindowPrivate) {
+        tab.isPrivate = PrivateBrowsingUtils.isContentWindowPrivate(win);
+      } else {
+        tab.isPrivate = PrivateBrowsingUtils.isWindowPrivate(win); // ESR 31
+      }
+
+      return tab;
+    }
+  } catch(err1) {
+    // requesting aLoadContext.topWindow when in e10s throws an error
+  }
+
+  return null;
 }
 
 function getLoadContext(aRequest) {

--- a/lib/tab/utils.js
+++ b/lib/tab/utils.js
@@ -14,6 +14,7 @@ const {
 } = require('chrome');
 const tabs = require('sdk/tabs');
 const {
+  getTabForBrowser,
   getTabForContentWindow
 } = require('sdk/tabs/utils');
 
@@ -59,20 +60,34 @@ function getTabForChannel(aHttpChannel) {
     // fallback
     return getTabForChannel2(aHttpChannel);
   }
-  var win = loadContext.topWindow;
-  if (win) {
-    var tab = getTabForContentWindow(win);
+
+  var tab = null;
+  if (loadContext.topFrameElement) {
+    var browser = loadContext.topFrameElement;
+    tab = getTabForBrowser(browser);
+
+    if ( tab ) {
+      tab.isPrivate = PrivateBrowsingUtils.isBrowserPrivate(browser);
+    } else {
+      // this function should return null if no tab can be found, not undefined
+      tab = null;
+    }
+  } else if (loadContext.topWindow) {
+    // Fallback for Firefox < 38, where topFrameElement is not defined when not
+    // in multiprocess mode. Note that this method crashes in multiprocess
+    // Firefox
+    var win = loadContext.topWindow;
+    tab = getTabForContentWindow(win);
+
     // http://developer.mozilla.org/en/docs/XUL:tab
     if (PrivateBrowsingUtils.isContentWindowPrivate) {
       tab.isPrivate = PrivateBrowsingUtils.isContentWindowPrivate(win);
     } else {
       tab.isPrivate = PrivateBrowsingUtils.isWindowPrivate(win); // ESR 31
     }
-    return tab;
-  } else {
-    // console.error('getTabForChannel() no topWindow found');
-    return null;
   }
+
+  return tab;
 }
 
 // Special case in case we don't have a load context.


### PR DESCRIPTION
Logging websites seems to be broken in multiprocess Firefox. Just run `cfx run --e10s` and you won't see any requests being tracked by Lightbeam (tested in Developer Edition 42.0a2 and Nightly 44.0a1).

The problem is in the part where the tab for each HTTP request is figured out in `lib/tab/utils.js`. It tries to do that through the load context's topWindow, which is unavailable in multiprocess Firefox. It crashes when you try to access it:

`Exception... "Component returned failure code: 0x8000ffff (NS_ERROR_UNEXPECTED) [nsILoadContext.topWindow]"  nsresult: "0x8000ffff (NS_ERROR_UNEXPECTED)"  location: "JS frame :: resource://gre/modules/commonjs/toolkit/loader.js -> resource://jid1-f9uj2thwoam5gq-at-jetpack/lightbeam/lib/tab/utils.js :: getTabForChannel :: line 62"  data: no`

I fixed it by using loadContext.topFrameElement in browsers that support it, which gives us a chrome browser object which we can work with.

Note that `getTabForChannel2` (a fallback function for `getTabForChannel`) should still always fail in multiprocess. The [alternative](https://developer.mozilla.org/en-US/Firefox/Multiprocess_Firefox/Limitations_of_chrome_scripts#HTTP_requests suggested by MDN) needs a load context, and this function is a fallback for when no load context is available. I couldn't find out why the fallback was needed, so I left it alone.