### PR TITLE
Move to jpm (fixes #669)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Install the git hooks for this project by:
 
 You can run the test suite like this:
 
-    cfx test
+    jpm test
 
 In addition to running the tests, you should lint the code. To install jshint, simply `npm install jshint` from the root directory of the project. Then run it like this:
 
@@ -16,4 +16,4 @@ In addition to running the tests, you should lint the code. To install jshint, s
 
 and make sure your changes are not adding any new warnings or errors.
 
-Also keep an eye on the command line warnings and errors when running the extension via `cfx run`.
+Also keep an eye on the command line warnings and errors when running the extension via `jpm run`.

--- a/README.md
+++ b/README.md
@@ -6,18 +6,13 @@ This is an add-on for Firefox that helps to visualize sites that may be tracking
 ## Prerequisites
 
 * [Mozilla Add-on SDK][ASDK]
-* [Firefox 29][] or higher.
+* [Firefox 38][] or higher.
 
 If you only want to see the demo, you don't need any of these; all you need is a modern browser.
 
 ## Quick Start
 
 First, [install][] the Mozilla Add-on SDK if you haven't already.
-
-Once it's installed, activate it in a command line terminal:
-
-    cd addon-sdk
-    source bin/activate
 
 Then, check out the Lightbeam repository and enter it (do this where you want the lightbeam directory, not in the addon-sdk directory):
 
@@ -26,13 +21,13 @@ Then, check out the Lightbeam repository and enter it (do this where you want th
 
 Finally, run:
 
-    cfx run
+    jpm run
 
 This will start Firefox with a temporary profile that has Lightbeam installed. Just click on the Lightbeam icon at the bottom-right of the browser window to open the web front-end.
 
-At this point, any changes you make to the web front-end simply require reloading the tab containing it. Changing the add-on, however, will require quitting Firefox and running `cfx run` again.
+At this point, any changes you make to the web front-end simply require reloading the tab containing it. Changing the add-on, however, will require quitting Firefox and running `jpm run` again.
 
-  [install]: https://developer.mozilla.org/en-US/Add-ons/SDK/Tutorials/Installation$revision/894679
+  [install]: https://developer.mozilla.org/en-US/Add-ons/SDK/Tools/jpm#Installation
 
 ## Software Used
 
@@ -42,8 +37,8 @@ The following software is bundled with the repository and doesn't need to be man
 * [PicoModal][]
 * [parseUri][]
 
-  [ASDK]: https://addons.mozilla.org/en-US/developers/builder
+  [ASDK]: https://developer.mozilla.org/en-US/Add-ons/SDK/Tools/jpm
   [D3]: http://mbostock.github.com/d3/
   [parseUri]: http://blog.stevenlevithan.com/code
   [PicoModal]: https://github.com/Nycto/PicoModal
-  [Firefox 29]: http://www.mozilla.com/en-US/firefox/fx/
+  [Firefox 38]: http://www.mozilla.com/en-US/firefox/fx/

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,7 +3,7 @@ To release a new version of Lightbeam:
 1. bump version number in `package.json` (the convention for version numbers is *major.minor.patch*)
 2. `git commit -a -m "Bump version to x.y.z"`
 3. `git tag lightbeam-x.y.z`
-4. using the latest ESR release of the addon SDK, run `cfx xpi` to generate `lightbeam.xpi`
+4. using the latest ESR release of the addon SDK, run `jpm xpi` to generate `lightbeam.xpi`
 5. log into <https://addons.mozilla.org> and click "Tools | Manage my submissions"
 6. find "Lightbeam" and click "New version" to upload the .xpi
 7. add something like "Added feature foo. Full changelog on <a href="https://github.com/mozilla/lightbeam/issues?q=milestone%3A1.2.0+is%3Aclosed">Github</a>." in the version notes.

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,11 +1,7 @@
 #!/bin/bash
 # Pre-push hook. If you want to test with a different version of firefox, put
-# the path in the CFX_FIREFOX environment variable.
+# the path in the JPM_FIREFOX_BINARY environment variable.
 
-cmd='cfx test'
-if [ -n "$CFX_FIREFOX" ];
-then
-  cmd="$cmd -b $CFX_FIREFOX"
-fi
+cmd='jpm test'
 echo $cmd
 $cmd

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -12,7 +12,7 @@ const {
 } = require("sdk/private-browsing");
 const {
   ContentPolicy
-} = require('shared/policy');
+} = require('lib/shared/policy');
 const ss = require('sdk/simple-storage');
 const prefs = require("sdk/simple-prefs").prefs;
 
@@ -230,7 +230,7 @@ function getLightbeamTab() {
 exports.getLightbeamTab = getLightbeamTab;
 
 // Set up the menu item to open the main UI page:
-var menuitem = require("shared/menuitems").Menuitem({
+var menuitem = require("lib/shared/menuitems").Menuitem({
   id: "lightbeam_openUITab",
   menuid: "menu_ToolsPopup",
   label: "Show Lightbeam",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
     "name": "lightbeam",
-    "fullName": "Lightbeam",
+    "title": "Lightbeam",
     "description": "Lightbeam is a Firefox add-on that allows you to see the third parties that are collecting information about your browsing activity, with and without your consent. Using interactive visualizations, Lightbeam shows you the relationships between these third parties and the sites you visit.",
     "author": "Mozilla Foundation",
     "license": "MPL 2.0",
     "version": "1.2.1",
-    "id": "jid1-F9UJ2thwoAm5gQ",
+    "id": "jid1-F9UJ2thwoAm5gQ@jetpack",
+    "main": "lib/main.js",
     "permissions": {
         "private-browsing": true
     },

--- a/test/test-ui.js
+++ b/test/test-ui.js
@@ -2,7 +2,7 @@
 
 const tabs = require('sdk/tabs');
 
-const { getLightbeamTab, mainPage, openOrSwitchToOrClose } = require('ui');
+const { getLightbeamTab, mainPage, openOrSwitchToOrClose } = require('../lib/ui');
 
 exports.testGetLightbeamTab = function(assert, done) {
   tabs.open({


### PR DESCRIPTION
I don't know if this is the kind of thing you accept random pull requests for, but since I already did this for myself and there was already an issue (#669) for it I might as well just give it a try.

This commit fixes the package.json, module paths, pre-push hook and docs to be compatible with jpm. It's important to note that this raises the minimum required Firefox version from 29 to 38. On the other hand, it makes working on Lightbeam easier as the documentation is easier to find*, it has a simpler installation procedure and it deals with unsigned add-ons out of the box (just some observations from a first-time add-on developer).

(* slightly less so since #694)