### PR TITLE
Added dialog to inform user of disabled cookies

### DIFF
--- a/data/dialog.js
+++ b/data/dialog.js
@@ -12,7 +12,8 @@ const dialogNames = {
   "stopUploadData": "stopUploadData",
   "privateBrowsing": "privateBrowsing",
   "trackingProtection": "trackingProtection",
-  "saveOldData": "saveOldData"
+  "saveOldData": "saveOldData",
+  "cookiesDisabled": "cookiesDisabled"
 };
 
 // options: name, title, message, type, dnsPrompt(Do Not Show), imageUrl
@@ -161,6 +162,19 @@ function assignTabIndices(modal) {
     }
   });
   dialogContainer.querySelector("[tabIndex='0']").focus();
+}
+
+function informUserofDisabledCookiesDialog() {
+    dialog({
+       "type": "alert",
+        "name": dialogNames.cookiesDisabled,
+        "dnsPrompt": true,
+        "title": "Cookies Disabled",
+        "message": "<p>You have disabled cookies.</p>" +
+            "<p>Lightbeam may not behave as expected. For full unhindered functionality please enable cookies.</p>"
+      },
+      function (confirmed) {}
+    );
 }
 
 function informUserOfUnsafeWindowsDialog() {


### PR DESCRIPTION
One part of issue https://github.com/mozilla/lightbeam/issues/668. I decided to navigator.enabledCookies instead of network.cookie.cookieBehavior. Is there any specific reason for the use of network.cookie.cookieBehaviour other than to check whether all or only some cookies have been disabled? 

Also Lightbeam seemed to work OK for me with cookies disabled so the message only says that it "may" be an issue.
