### PR TITLE
Replace nonstandard for-each-in loop with for-of

### DIFF
--- a/lib/ui.js
+++ b/lib/ui.js
@@ -221,7 +221,7 @@ function attachToLightbeamPage(worker) {
 // This lets us toggle between the 3 states (no lightbeam tab open, lightbeam
 // tab open but it's not the tab you're on, you're on the lightbeam tab)
 function getLightbeamTab() {
-  for each(let tab in tabs) {
+  for (let tab of tabs) {
     if (tab.url.slice(0, mainPage.length) === mainPage) {
       return tab;
     }


### PR DESCRIPTION
Lightbeam is broken in Firefox Nightly 53 because Nightly no longer supports the nonstandard for-each-in loops. See [Firefox bug 1293305](https://bugzil.la/1293305).